### PR TITLE
fix: Railway デプロイエラー修正

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,14 +5,15 @@ WORKDIR /app
 # システムの依存関係をインストール
 RUN apt-get update && apt-get install -y \
     gcc \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # 依存パッケージをインストール
-COPY requirements.txt .
+COPY backend/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # アプリケーションコードをコピー
-COPY . .
+COPY backend/ .
 
 # ポート設定（Railwayが動的に割り当て）
 EXPOSE ${PORT:-8000}


### PR DESCRIPTION
- Dockerfileのパスを修正（プロジェクトルートから相対パス指定）
- curlをDockerイメージに追加（ヘルスチェック用）
- ビルドコンテキストの問題を解決