### PR TITLE
fix: Fix Railway deployment main.py path issue

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,7 +13,7 @@ COPY backend/requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # アプリケーションコードをコピー
-COPY . .
+COPY backend/ .
 
 # ポート設定（Railwayが動的に割り当て）
 EXPOSE ${PORT:-8000}


### PR DESCRIPTION
## Railwayデプロイエラーの修正
### backend/Dockerfile
- Railwayデプロイ時にmain.pyが見つからないエラーを修正するため、COPY . . を COPY backend/ . に変更し、backendフォルダの内容を直接/appにコピーするようにした

## 影響範囲
- Railwayへのデプロイプロセス

## ユーザー体験向上/システム改善
- Railwayでのデプロイが正常に動作するようになる